### PR TITLE
Enforce client to send all arguments required by an RPC method

### DIFF
--- a/lib/method.js
+++ b/lib/method.js
@@ -95,8 +95,12 @@ Method.prototype._getHandlerParams = function(params) {
 
     if(isObjectParams) {
       // named parameters passed, take all parameters for handler except last (the callback)
+      // and place them in an array. If any parameters are undefined, remove them from the
+      // array so RPC will return an invalid params error
       return _.initial(utils.getParameterNames(handler)).map(function(name) {
         return params[name];
+      }).filter(function(value) {
+        return typeof value !== 'undefined'; 
       });
     }
 

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -386,11 +386,11 @@ describe('Jayson.Server', function() {
         });
       });
 
-      it('should not fail when not given sufficient arguments', function(done) {
+      it('should fail when not given sufficient arguments', function(done) {
         var request = utils.request('add', {});
         server.call(request, function(err, response) {
-          if(err) return done(err);
-          isNaN(response.result).should.equal(true);
+          should.not.exist(response);
+          err.should.containDeep({error: {code: ServerErrors.INVALID_PARAMS}});
           done();
         });
       });


### PR DESCRIPTION
I'm just going to park this here for now. It requires that all RPC method arguments are specified by the client. For example, the method:

`authorizedAddition(n1, n2, token, done)`

Would require the client to provide all necessary arguments

`{n1: 1, n2: 1, token: "abcd"}`

If the client omitted an argument, they would get an Invalid params error from RPC. The following would produce such error:

`{n1: 1, token: "abcd"}`

However, this change would not allow for optional parameters to be defined in RPC methods and if we want to have a method to update a users information where you can optionally supply a new password, or new username, or new etc. this would not be possible.
